### PR TITLE
Replace length-based tests

### DIFF
--- a/tests/testthat/test_events.R
+++ b/tests/testthat/test_events.R
@@ -48,5 +48,5 @@ test_that("convolve_events", {
 # plot_events
 test_that("plot_events", {
   plot <- plot_events(autofit[[1]])
-  expect_equal(length(plot), 9)
+  expect_s3_class(plot, "ggplot")
 })

--- a/tests/testthat/test_modelling.R
+++ b/tests/testthat/test_modelling.R
@@ -52,13 +52,13 @@ test_that("evaluate_model_single", {
 # plot_model
 test_that("plot_model", {
   plot <- plot_model(em)
-  expect_equal(length(plot), 9)
+  expect_s3_class(plot, "ggplot")
 })
 
 # plot_model by roi
 test_that("plot_model_by_roi", {
   plot <- plot_model(em, by_roi = TRUE)
-  expect_equal(length(plot), 9)
+  expect_s3_class(plot, "ggplot")
 })
 
 # autohrf ----------------------------------------------------------------------
@@ -108,7 +108,7 @@ test_that("autohrf_parallel", {
 # plot_best_models
 test_that("plot_best_models", {
   plot <- plot_best_models(autofit)
-  expect_equal(length(plot), 9)
+  expect_s3_class(plot, "ggplot")
 })
 
 # get_best_models_return_fitness


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break autohrf.

This PR updates some tests that expected that the result of `ggplot()` has length 9, which is no longer true in the release candidate. These tests have been replaced with tests that check that the outcome of the plotting functions return a ggplot object.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of Februari. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help autohrf get out a fix if necessary.